### PR TITLE
Fix fields order

### DIFF
--- a/django_zip_stream/responses.py
+++ b/django_zip_stream/responses.py
@@ -31,5 +31,5 @@ class TransferZipResponse(HttpResponse):
         assembles a string containing mod_zip commands for a single file.
         """
         path, system_path, size = file_info
-        single_file_info = "- %s %s %s" % (path, system_path, size)
+        single_file_info = "- %s %s %s" % (size, system_path, path)
         return single_file_info

--- a/tests/test_zipstream.py
+++ b/tests/test_zipstream.py
@@ -17,7 +17,7 @@ class TransferZipResponseTestCase(django.test.TestCase):
         self.assertEqual(response['Content-Type'], 'application/zip')
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.content,
-                         b"- /chicago.jpg /home/django/chicago.jpg 4096")
+                         b"- 4096 /home/django/chicago.jpg /chicago.jpg")
 
     def test_zip_multiple_files(self):
         """ Test creating a zip for multiple files. """
@@ -30,5 +30,5 @@ class TransferZipResponseTestCase(django.test.TestCase):
         self.assertEqual(response['Content-Type'], 'application/zip')
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.content,
-                         b"- /chicago.jpg /home/django/chicago.jpg 4096\n"
-                         b"- /portland.jpg /home/django/portland.jpg 4096")
+                         b"- 4096 /home/django/chicago.jpg /chicago.jpg\n"
+                         b"- 4096 /home/django/portland.jpg /portland.jpg")


### PR DESCRIPTION
Hey!

According to [official documentation](https://github.com/evanmiller/mod_zip/blob/master/README.markdown#usage) of nginx's mod_zip, the correct order of fields in response body is ``CRC-32 size location name``; but not ``CRC-32 name location size``, as it has been in the package.

This fixes it.